### PR TITLE
Add basic starter tasks to todo list

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,4 @@
+# Guidelines for Codex Agents
+
+- Alle Entwickler sollen geaenderte Dateien mit dem Suffix `.todo` oder `.erledigt` versehen, solange das Projekt noch nicht veroeffentlicht ist.
+- Nach dem Release koennen die Suffixe entfernt werden.

--- a/README.md
+++ b/README.md
@@ -77,3 +77,17 @@ Sieh dir auch die Datei `todo.txt` an und hänge dort eigene Aufgaben an.
    git commit -m "Beispielmodul und Konfiguration"
    ```
    Mit Git bewahrst du den aktuellen Stand deines Projekts auf.
+
+10. **Pre-Commit-Hooks ausfuehren** (`pre-commit`; automatische Pruefungen):
+    ```bash
+    bash scripts/pre-commit
+    ```
+    Dieser Schritt startet kleine Tests vor jedem Git-Commit.
+
+11. **Aenderungen online stellen** (`push`; Hochladen zu GitHub):
+    ```bash
+    git push origin main
+    ```
+    So landet dein Code in deinem Online-Repository.
+
+Sieh ausserdem in `modul-pool.txt` nach Ideen fuer weitere Module.

--- a/README.md
+++ b/README.md
@@ -54,3 +54,26 @@ Sieh dir auch die Datei `todo.txt` an und hänge dort eigene Aufgaben an.
    pytest -q
    ```
    Damit pruefst du, ob alles fehlerfrei laeuft.
+
+## Noch mehr Tipps
+
+7. **Eigenes Modul schreiben** (`module`; kleines Code-Stueck):
+   ```bash
+   echo 'print("Hallo WIZZARD")' > modules/beispiel.py
+   python modules/beispiel.py
+   ```
+   Ein Modul ist eine einzelne Python-Datei, in der du erste Funktionen testen kannst.
+
+8. **Konfiguration bearbeiten** (`configuration`; Einstellungen):
+   ```bash
+   nano config/defaults.yaml
+   ```
+   In dieser Datei kannst du zum Beispiel `app_name: WIZZARD` eintragen. Damit steuerst du Standardwerte.
+
+9. **Aenderungen speichern** (`commit`; Sicherungsschritt):
+   ```bash
+   git status
+   git add modules/beispiel.py config/defaults.yaml
+   git commit -m "Beispielmodul und Konfiguration"
+   ```
+   Mit Git bewahrst du den aktuellen Stand deines Projekts auf.

--- a/README.md
+++ b/README.md
@@ -33,3 +33,24 @@ Dieses Projekt stellt eine leere Grundstruktur für das WIZZARD Tool bereit. Du 
   ```
 
 Sieh dir auch die Datei `todo.txt` an und hänge dort eigene Aufgaben an.
+
+## Weitere Schritte fuer Neulinge
+
+4. **Geheimnisse-Datei** (`secrets file`):
+   ```bash
+   cp config/secrets.example.json config/secrets.json
+   ```
+   Damit legst du deine persoenliche Schluesseldatei an.
+
+5. **Code formatieren** (`formatter`):
+   ```bash
+   pip install black
+   black .
+   ```
+   `black` sorgt fuer gleichmaessige Formatierung deines Quellcodes.
+
+6. **Tests ausfuehren** (`testing`):
+   ```bash
+   pytest -q
+   ```
+   Damit pruefst du, ob alles fehlerfrei laeuft.

--- a/README.md
+++ b/README.md
@@ -91,3 +91,23 @@ Sieh dir auch die Datei `todo.txt` an und hänge dort eigene Aufgaben an.
     So landet dein Code in deinem Online-Repository.
 
 Sieh ausserdem in `modul-pool.txt` nach Ideen fuer weitere Module.
+
+## Weitere einfache Vorschlaege
+
+12. **Backup erstellen** (`backup`; Sicherung des Projekts):
+    ```bash
+    zip -r project_backup.zip .
+    ```
+    Damit sicherst du alle Dateien in einer Archivdatei.
+
+13. **Text durchsuchen** (`grep`; Suche in Dateien):
+    ```bash
+    grep -R "Beispiel" .
+    ```
+    So findest du schnell Stellen mit einem bestimmten Wort.
+
+14. **Abhaengigkeiten einfrieren** (`freeze`; Versionen merken):
+    ```bash
+    pip freeze > requirements.txt
+    ```
+    Dadurch speicherst du alle installierten Bibliotheken in `requirements.txt`.

--- a/modul-pool.txt
+++ b/modul-pool.txt
@@ -1,0 +1,9 @@
+# Modul-Pool
+
+Hier findest du einfache Ideen fuer neue Module.
+
+- Statistik-Modul (analytics): Daten sammeln und grafisch darstellen.
+- Chat-Modul (chat): Textunterhaltung innerhalb des Tools.
+- Wetter-Modul (weather): Wettervorhersage aus dem Internet.
+- Timer-Modul (timer): Erinnerungen und Countdown.
+- Demo-Plugin (demo-plugin): Vorlage fuer eigene Experimente.

--- a/todo.txt
+++ b/todo.txt
@@ -9,3 +9,8 @@
 - [ ] Theming vereinheitlichen und Fehlermeldungen anzeigen
 - [ ] Unit- und UI-Tests mit pytest-qt erstellen
 - [ ] start_wizard.sh um Logging und Parameter erweitern
+
+- [ ] Virtuelle Umgebung einrichten
+- [ ] Abhaengigkeiten mit pip installieren
+- [ ] Konfiguration pruefen und anpassen
+- [ ] start_wizard.sh ausprobieren

--- a/todo.txt
+++ b/todo.txt
@@ -14,3 +14,6 @@
 - [ ] Abhaengigkeiten mit pip installieren
 - [ ] Konfiguration pruefen und anpassen
 - [ ] start_wizard.sh ausprobieren
+- [ ] secrets.example.json kopieren
+- [ ] Code mit black formatieren
+- [ ] Tests mit pytest ausfuehren

--- a/todo.txt
+++ b/todo.txt
@@ -24,3 +24,6 @@
 - [ ] Pre-Commit-Hooks ausfuehren
 - [ ] Code zu GitHub pushen
 - [ ] Modulideen pruefen
+- [ ] Backup des Projekts erstellen
+- [ ] Textsuche mit grep ausprobieren
+- [ ] Abhaengigkeiten einfrieren

--- a/todo.txt
+++ b/todo.txt
@@ -17,3 +17,6 @@
 - [ ] secrets.example.json kopieren
 - [ ] Code mit black formatieren
 - [ ] Tests mit pytest ausfuehren
+- [ ] Eigenes Modul schreiben
+- [ ] defaults.yaml bearbeiten
+- [ ] Aenderungen mit Git committen

--- a/todo.txt
+++ b/todo.txt
@@ -20,3 +20,7 @@
 - [ ] Eigenes Modul schreiben
 - [ ] defaults.yaml bearbeiten
 - [ ] Aenderungen mit Git committen
+
+- [ ] Pre-Commit-Hooks ausfuehren
+- [ ] Code zu GitHub pushen
+- [ ] Modulideen pruefen


### PR DESCRIPTION
## Summary
- extend `todo.txt` with beginner-friendly setup steps

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68671948ad508325b2164766d3a87807